### PR TITLE
adjust vertical velocity for scrolls to top by tapping status bar

### DIFF
--- a/Example/FlabbyTable/FlabbyTable/BRFlabbyTableManager.m
+++ b/Example/FlabbyTable/FlabbyTable/BRFlabbyTableManager.m
@@ -157,7 +157,12 @@ static NSString *flabbyKeyPath = @"contentOffset";
             CGFloat verticalVelocity =  oldOffset.y - newOffset.y;
             if (fabsf(verticalVelocity - _previousVerticalVelocity)>CGFLOAT_MIN) {
                 if (verticalVelocity/newOffset.y > 1.05 || verticalVelocity/newOffset.y < 0.95) {
-                    [self applyFlabbinessForVerticalVelocity:verticalVelocity];
+                    BOOL didScrollToTop = newOffset.y == -_tableView.contentInset.top;
+                    if (didScrollToTop) {
+                        [self applyFlabbinessForVerticalVelocity:0.f];
+                    } else {
+                        [self applyFlabbinessForVerticalVelocity:verticalVelocity];
+                    }
                 }
             }
         }


### PR DESCRIPTION
After scrolling to top by tapping status bar,  the shape of the cell remain bent. 
like this:
http://gyazo.com/7645459950d0b2bf3fd9cd4ed003790d

So, I changed vertical velocity when newOffset is content top.
